### PR TITLE
Avoid 'undefined undefined' displayName

### DIFF
--- a/lib/passport-openid/strategy.js
+++ b/lib/passport-openid/strategy.js
@@ -392,7 +392,9 @@ Strategy.prototype._parseProfileExt = function(params) {
   profile.name = { familyName: params['lastname'],
                    givenName: params['firstname'] };
   if (!profile.displayName) {
-    profile.displayName = params['firstname'] + ' ' + params['lastname'];
+    if(params['firstname'] && params['lastname']) {
+      profile.displayName = params['firstname'] + ' ' + params['lastname'];
+    }
   }
   if (!profile.emails) {
     profile.emails = [{ value: params['email'] }];


### PR DESCRIPTION
When a provider does not provide the full name of the user, displayName is set to 'undefined undefined', which is annoying.

Added the condition to only set displayName if firstname and lastname parameters are set, so applications can handle empty names.
