### PR TITLE
Support for PAPE: the OpenID Provider Authentication Policy Extension

### DIFF
--- a/lib/passport-openid/strategy.js
+++ b/lib/passport-openid/strategy.js
@@ -107,11 +107,11 @@ function Strategy(options, verify) {
 
   if (options.pape) {
     var papeOptions = {};
-    if (options.pape.hasOwnProperty('maxAuthAge')) {
+    if (options.pape.hasOwnProperty("maxAuthAge")) {
       papeOptions.max_auth_age = options.pape.maxAuthAge;
 	  }
     if (options.pape.preferredAuthPolicies) {
-      if (typeof options.pape.preferredAuthPolicies === 'string') {
+      if (typeof options.pape.preferredAuthPolicies === "string") {
         papeOptions.preferred_auth_policies = options.pape.preferredAuthPolicies;
       } else if (Array.isArray(options.pape.preferredAuthPolicies)) {
         papeOptions.preferred_auth_policies = options.pape.preferredAuthPolicies.join(" ");
@@ -177,36 +177,48 @@ Strategy.prototype.authenticate = function(req) {
         self.success(user, info);
       }
       
-      // invoke callback with some combination of req, claimedIdentifier, 
-      // profile, pape, verified, depending on the function's length.
       var arity = self._verify.length;
-      if (self._passReqToCallback) {
-        if (arity === 5) {
-          self._verify(req, result.claimedIdentifier, profile, pape, verified);
-        } else if (arity === 4) {
+      // invoke callback with some combination of req, claimedIdentifier, 
+      // profile, pape and verified.  The exact number of arguments to use 
+      // depends on the function's length and the settings of 
+      // self._passReqToCallback, self._profile and self._pape.
+           
+      // first handle cases with no ambiguity: we always know what to do.
+      if (arity === 2) {
+        self._verify(result.claimedIdentifier, verified);
+      } else if (arity === 3 && self._passReqToCallback) {
+        self._verify(req, result.claimedIdentifier, verified);
+      } else if (arity === 4 && !self._passReqToCallback) {
+        self._verify(result.claimedIdentifier, profile, pape, verified);
+      } else if (arity === 5) {
+        self._verify(req, result.claimedIdentifier, profile, pape, verified);
+      } else if (arity === 0 && self._passReqToCallback && self._profile && self._pape) {
+        self._verify(req, result.claimedIdentifier, profile, pape, verified);
+      } else if (arity === 0 && !self._passReqToCallback && self._profile && self._pape) {
+        self._verify(result.claimedIdentifier, profile, pape, verified);
+      } else if (arity === 0 && self._passReqToCallback && !self._profile && !self._pape) {
+        self._verify(req, result.claimedIdentifier, verified);
+      } else if (arity === 0 && !self._passReqToCallback && !self._profile && !self._pape) {
+        self._verify(result.claimedIdentifier, verified);
+      }
+      else {
+      // Ambiguous situation: the function only has enough arguments for one 
+      // of the PAPE or Profile extension results. Prefer the profile result 
+      // object over PAPE, should both have been requested.
+        if (self._passReqToCallback) {
           if (self._profile) {
-            //profile seems most likely
             self._verify(req, result.claimedIdentifier, profile, verified);
-          } else if (self._pape) {
+          } else {
             self._verify(req, result.claimedIdentifier, pape, verified);
           }
         } else {
-          self._verify(req, result.claimedIdentifier, verified);
-        }
-      } else {
-        if (arity === 4) {
-          self._verify(result.claimedIdentifier, profile, pape, verified);
-        } else if (arity === 3) {
           if (self._profile) {
-            //profile seems most likely
             self._verify(result.claimedIdentifier, profile, verified);
-          } else if (self._pape) {
+          } else {
             self._verify(result.claimedIdentifier, pape, verified);
           }
-        } else {
-          self._verify(result.claimedIdentifier, verified);
         }
-      }
+      }  
     });
   } else {
     // The request being authenticated is initiating OpenID authentication.  By

--- a/test/strategy-test.js
+++ b/test/strategy-test.js
@@ -5,7 +5,6 @@ var openid = require('openid');
 var OpenIDStrategy = require('passport-openid/strategy');
 var BadRequestError = require('passport-openid/errors/badrequesterror');
 
-
 vows.describe('OpenIDStrategy').addBatch({
   
   'strategy': {
@@ -172,6 +171,7 @@ vows.describe('OpenIDStrategy').addBatch({
     topic: function() {
       var strategy = new OpenIDStrategy({
           returnURL: 'https://www.example.com/auth/openid/return',
+          profile: true
         },
         function(identifier, profile, done) {
           done(null, { identifier: identifier, displayName: profile.displayName, emails: profile.emails });
@@ -222,6 +222,9 @@ vows.describe('OpenIDStrategy').addBatch({
         assert.equal(req.user.identifier, 'http://www.example.com/profiles/username');
       },
       'should parse profile' : function(err, req) {
+        /* This test did not enable the 'profile' setting, so it seemed 
+         * unreasonable to require profile information.  It has now been 
+         * changed to enable profile. */
         assert.equal(req.user.displayName, 'John Doe');
         assert.lengthOf(req.user.emails, 1);
         assert.equal(req.user.emails[0].value, 'username@example.com');
@@ -229,10 +232,63 @@ vows.describe('OpenIDStrategy').addBatch({
     },
   },
   
+  'strategy handling an authorized request with provider authentication policy extensions (pape)': {
+    topic: function() {
+      var strategy = new OpenIDStrategy({
+          returnURL: 'https://www.example.com/auth/openid/return',
+          pape : { 'maxAuthAge' : 600, 'preferredAuthPolicies' : 'multi-factor multi-factor-physical' }
+        },
+        function(identifier, pape, done) {
+          done(null, { identifier: identifier, pape: pape });
+        }
+      );
+      
+      // mock
+      strategy._relyingParty.verifyAssertion = function(url, callback) {
+        callback(null, { authenticated: true, claimedIdentifier: 'http://www.example.com/profiles/username', 
+                         'auth_policies' : 'none', 'auth_time': new Date() } );
+      }
+      
+      return strategy;
+    },
+    
+    'after augmenting with actions': {
+      topic: function(strategy) {
+        var self = this;
+        var req = {};
+        strategy.success = function(user) {
+          req.user = user;
+          self.callback(null, req);
+        }
+        strategy.fail = function() {
+          self.callback(new Error('should not be called'));
+        }
+        
+        req.query = {};
+        req.query['openid.mode'] = 'id_res'
+        process.nextTick(function () {
+          strategy.authenticate(req);
+        });
+      },
+      
+      'should not call fail' : function(err, req) {
+        assert.isNull(err);
+      },
+      'should authenticate' : function(err, req) {
+        assert.equal(req.user.identifier, 'http://www.example.com/profiles/username');
+      },
+      'should parse pape' : function(err, req) {
+        assert.lengthOf(req.user.pape.authPolicies, 1);
+        assert.instanceOf(req.user.pape.authTime, Date);
+      },
+    },
+  },  
+  
   'strategy handling an authorized request with attribute exchange extensions': {
     topic: function() {
       var strategy = new OpenIDStrategy({
           returnURL: 'https://www.example.com/auth/openid/return',
+          profile: true
         },
         function(identifier, profile, done) {
           done(null, { identifier: identifier, displayName: profile.displayName, name: profile.name, emails: profile.emails });
@@ -277,6 +333,9 @@ vows.describe('OpenIDStrategy').addBatch({
         assert.equal(req.user.identifier, 'http://www.example.com/profiles/username');
       },
       'should parse profile' : function(err, req) {
+        /* This test did not enable the 'profile' setting, so it seemed 
+         * unreasonable to require profile information.  It has now been 
+         * changed to enable profile. */
         assert.equal(req.user.displayName, 'John Doe');
         assert.equal(req.user.name.familyName, 'Doe');
         assert.equal(req.user.name.givenName, 'John');
@@ -297,7 +356,6 @@ vows.describe('OpenIDStrategy').addBatch({
           var identifier = arguments[0];
           var profile = arguments[1];
           var done = arguments[2];
-          
           done(null, { identifier: identifier, displayName: profile.displayName, name: profile.name, emails: profile.emails });
         }
       );
@@ -353,6 +411,7 @@ vows.describe('OpenIDStrategy').addBatch({
     topic: function() {
       var strategy = new OpenIDStrategy({
           returnURL: 'https://www.example.com/auth/openid/return',
+          profile: true,
           passReqToCallback: true
         },
         function(req, identifier, profile, done) {
@@ -402,6 +461,9 @@ vows.describe('OpenIDStrategy').addBatch({
         assert.equal(req.user.foo, 'bar');
       },
       'should parse profile' : function(err, req) {
+        /* This test did not enable the 'profile' setting, so it seemed 
+         * unreasonable to require profile information.  It has now been 
+         * changed to enable profile. */
         assert.equal(req.user.displayName, 'John Doe');
         assert.equal(req.user.name.familyName, 'Doe');
         assert.equal(req.user.name.givenName, 'John');


### PR DESCRIPTION
This pull request provides the passport-openid module with support for the OpenID Provider Authentication Policy Extension (PAPE), as recently added to the node-openid module ( https://github.com/havard/node-openid/commit/5bb00828d46d67dce086fb1348efa56ffe8d03fd ).

The changes consist of some additional code in the strategy file, a new callback invoking section in "verifyAssertion", plus a new test case and a few changes to existing test cases.

Note: this will work with the github version of node-openid, but not the module on NPM, as this has not been updated yet.
