### PR TITLE
Add a new field in the AttributeExchange to support Yahoo display names.

### DIFF
--- a/lib/passport-openid/strategy.js
+++ b/lib/passport-openid/strategy.js
@@ -89,6 +89,7 @@ function Strategy(options, verify) {
   }
   if (options.profile) {
     var ax = new openid.AttributeExchange({
+      "http://axschema.org/namePerson" : "required",
       "http://axschema.org/namePerson/first": "required",
       "http://axschema.org/namePerson/last": "required",
       "http://axschema.org/contact/email": "required"


### PR DESCRIPTION
Yahoo does not return "http://axschema.org/namePerson/first", but requires
"http://axschema.org/namePerson" instead.  This commit adds the attribute.
