### PR TITLE
Creating the OpenIDStrategy when request is available

### DIFF
--- a/examples/signon/app.js
+++ b/examples/signon/app.js
@@ -23,7 +23,7 @@ passport.deserializeUser(function(identifier, done) {
 //   Strategies in passport require a `validate` function, which accept
 //   credentials (in this case, an OpenID identifier), and invoke a callback
 //   with a user object.
-function setNewOpenIdStrategy(req, res, next){
+function setNewOpenIdStrategy(req){
   var host = req.host,
     returnURL = 'http://'+host+':' + port + '/auth/openid/return',
     realm =  'http://'+host+':' + port;
@@ -38,7 +38,6 @@ function setNewOpenIdStrategy(req, res, next){
       });
     }
   ));
-  next();
 }
 
 
@@ -82,8 +81,10 @@ app.get('/login', function(req, res){
 //   provider will redirect the user back to this application at
 //   /auth/openid/return
 app.post('/auth/openid',
-  setNewOpenIdStrategy,
-  passport.authenticate('openid', { failureRedirect: '/login' }),
+  function(req, res, next){
+    setNewOpenIdStrategy(req);
+    passport.authenticate('openid', { failureRedirect: '/login' })(req, res, next);
+  },
   function(req, res) {
     res.redirect('/');
   });
@@ -94,8 +95,10 @@ app.post('/auth/openid',
 //   login page.  Otherwise, the primary route function function will be called,
 //   which, in this example, will redirect the user to the home page.
 app.get('/auth/openid/return',
-  setNewOpenIdStrategy,
-  passport.authenticate('openid', { failureRedirect: '/login' }),
+  function(req, res, next){
+    setNewOpenIdStrategy(req);
+    passport.authenticate('openid', { failureRedirect: '/login' })(req, res, next);
+  },
   function(req, res) {
     res.redirect('/');
   });


### PR DESCRIPTION
Hello,

above all thank you very much for work and sharing of your middleware, I like it very much and find it really easy to use. I would like to make one suggestion.

Configuring open id strategy requires knowledge of host URL used to define returnURL and realm. These values are not always known a priory during the application development. They also can differ in test and productive environments. Therefore is seems to be an advantage if the strategy can be configured after the request containing the host URL is already available. 

Therefore I changed your login example so that the strategy is set when the authentication request is processed. It means that a new strategy object is used every time. 

I would like to ask you to check if it is a valid usage of your software. If it can be done this way may be you want to include my solution in your example. If something is wrong please give a hint what should be changed.

Kind regards, 
Dimitry Polivaev
