### PR TITLE
Fix for false "internal error" message in Browser 

### DIFF
--- a/lib/passport-openid/strategy.js
+++ b/lib/passport-openid/strategy.js
@@ -246,7 +246,7 @@ Strategy.prototype.authenticate = function(req) {
 
     var self = this;
     this._relyingParty.authenticate(identifier, false, function(err, providerUrl) {
-      if (err || !providerUrl) { return self.error(new InternalOpenIDError('Failed to discover OP endpoint URL', err)); }
+      if (err || !providerUrl) { return self.fail(new InternalOpenIDError('Failed to discover OP endpoint URL', err)); }
       self.redirect(providerUrl);
     });
   }


### PR DESCRIPTION
Hello, 

the issue already described in https://github.com/jaredhanson/passport-google/issues/3 unfortunately occurs in vanilla openid apps too. So if I run your example and enter a wrong URL in the login field like this
![login](https://f.cloud.github.com/assets/1558052/366202/49745b46-a279-11e2-861b-9e2178e583d2.png)
I get an error stack trace displayed in the browser.
![afterLogin](https://f.cloud.github.com/assets/1558052/366206/85b2db0a-a279-11e2-9077-e68d1ad64629.png)
The reason for this behavior is that the strategy interpretes a wrong URL as internal error although it can actually be entered by a user.
After applying the suggested fix the wrong input results in a redirect back to the login page which I think is a correct behavior.
Please check this issue, it is a show stopper.

Kind regards, Dimitry
