### PR TITLE
Add the ability to set custom fetch attributes as an option on the OpenID strategy

### DIFF
--- a/lib/passport-openid/strategy.js
+++ b/lib/passport-openid/strategy.js
@@ -100,10 +100,9 @@ function Strategy(options, verify) {
   var attributes = {};
   if (options.profile) {
     attributes = {
-      "http://axschema.org/namePerson" : "required",
-      "http://axschema.org/namePerson/first": "required",
-      "http://axschema.org/namePerson/last": "required",
-      "http://axschema.org/contact/email": "required"
+      "http://openid.net/schema/namePerson/first": "required",
+      "http://openid.net/schema/namePerson/last": "required",
+      "http://openid.net/schema/contact/internet/email": "required"
     };
   }
   if (options.extensions) {
@@ -452,18 +451,15 @@ Strategy.prototype._parseProfileExt = function(params) {
   
   // parse simple registration parameters
   profile.displayName = params['fullname'];
-  profile.emails = [{ value: params['email'] }];
+  profile.email = params['email'];
   
   // parse attribute exchange parameters
-  profile.name = { familyName: params['lastname'],
-                   givenName: params['firstname'] };
+  profile.name = { familyName: params['last'],
+                   givenName: params['first'] };
   if (!profile.displayName) {
-    if (params['firstname'] && params['lastname']) {
-      profile.displayName = params['firstname'] + ' ' + params['lastname'];
+    if (params['first'] && params['last']) {
+      profile.displayName = params['first'] + ' ' + params['last'];
     }
-  }
-  if (!profile.emails) {
-    profile.emails = [{ value: params['email'] }];
   }
 
   return profile;

--- a/lib/passport-openid/strategy.js
+++ b/lib/passport-openid/strategy.js
@@ -451,15 +451,14 @@ Strategy.prototype._parseProfileExt = function(params) {
   
   // parse simple registration parameters
   profile.displayName = params['fullname'];
-  profile.email = params['email'];
+  // TODO: The hard-coded alias stuff really needs to go.
+  profile.email = params['email'] || params['alias1'];
   
   // parse attribute exchange parameters
-  profile.name = { familyName: params['last'],
-                   givenName: params['first'] };
+  profile.name = { familyName: params['last'] || params['alias3'],
+                   givenName: params['first'] || params['alias2'] };
   if (!profile.displayName) {
-    if (params['first'] && params['last']) {
-      profile.displayName = params['first'] + ' ' + params['last'];
-    }
+    profile.displayName = (params['first'] || params['alias2']) + (params['last'] || params['alias3']);
   }
 
   return profile;

--- a/lib/passport-openid/strategy.js
+++ b/lib/passport-openid/strategy.js
@@ -449,16 +449,20 @@ Strategy.prototype.loadDiscoveredInformation = function(fn) {
 Strategy.prototype._parseProfileExt = function(params) {
   var profile = {};
   
-  // parse simple registration parameters
   profile.displayName = params['fullname'];
   // TODO: The hard-coded alias stuff really needs to go.
-  profile.email = params['email'] || params['alias1'];
-  
+  var email = params['email'] || params['alias1'];
+  var first = params['first'] || params['alias2'];
+  var last = params['last'] || params['alias3'];
+
+  profile.email = email;
   // parse attribute exchange parameters
-  profile.name = { familyName: params['last'] || params['alias3'],
-                   givenName: params['first'] || params['alias2'] };
+  profile.name = { familyName: last,
+                   givenName: first };
   if (!profile.displayName) {
-    profile.displayName = (params['first'] || params['alias2']) + (params['last'] || params['alias3']);
+    if (first && last) {
+      profile.displayName = first + ' ' + last;
+    }
   }
 
   return profile;

--- a/lib/passport-openid/strategy.js
+++ b/lib/passport-openid/strategy.js
@@ -96,13 +96,23 @@ function Strategy(options, verify) {
     });
     extensions.push(sreg);
   }
+
+  var attributes = {};
   if (options.profile) {
-    var ax = new openid.AttributeExchange({
+    attributes = {
       "http://axschema.org/namePerson" : "required",
       "http://axschema.org/namePerson/first": "required",
       "http://axschema.org/namePerson/last": "required",
       "http://axschema.org/contact/email": "required"
+    };
+  }
+  if (options.extensions) {
+    Object.keys(options.extensions).forEach(function (ext) {
+      attributes[ext] = options.extensions[ext];
     });
+  }
+  if (Object.keys(attributes).length > 0) {
+    var ax = new openid.AttributeExchange(attributes);
     extensions.push(ax);
   }
 
@@ -116,7 +126,7 @@ function Strategy(options, verify) {
     var papeOptions = {};
     if (options.pape.hasOwnProperty("maxAuthAge")) {
       papeOptions.max_auth_age = options.pape.maxAuthAge;
-	  }
+    }
     if (options.pape.preferredAuthPolicies) {
       if (typeof options.pape.preferredAuthPolicies === "string") {
         papeOptions.preferred_auth_policies = options.pape.preferredAuthPolicies;

--- a/lib/passport-openid/strategy.js
+++ b/lib/passport-openid/strategy.js
@@ -455,7 +455,7 @@ Strategy.prototype._parseProfileExt = function(params) {
   var first = params['first'] || params['alias2'];
   var last = params['last'] || params['alias3'];
 
-  profile.email = email;
+    profile.emails = [{ value: email }];
   // parse attribute exchange parameters
   profile.name = { familyName: last,
                    givenName: first };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "passport-openid",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "description": "OpenID authentication strategy for Passport.",
   "keywords": ["passport", "openid", "auth", "authn", "authentication", "identity"],
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "passport-openid",
-  "version": "0.3.1",
+  "version": "0.3.3",
   "description": "OpenID authentication strategy for Passport.",
   "keywords": ["passport", "openid", "auth", "authn", "authentication", "identity"],
   "repository": {


### PR DESCRIPTION
This adds a new attribute "extensions" on the options object that is passed to the OpenID strategy upon initialization.  This new attribute is a key/value pair of additional OpenID attributes (see the Attribute Exchange spec) that will be requested from the OpenID provider.  The key is the URL of the attribute, e.g. "http://schema.openid.net/contact/email", and the value is either "required" or "optional", which instructs the OpenID provider on how to respond if it cannot deliver the information.
