### PR TITLE
express.createServer() is deprecated

### DIFF
--- a/examples/signon/app.js
+++ b/examples/signon/app.js
@@ -44,7 +44,6 @@ passport.use(new OpenIDStrategy({
 
 
 
-var express = require("express");
 var app = express();
 
 // configure Express

--- a/examples/signon/app.js
+++ b/examples/signon/app.js
@@ -44,7 +44,8 @@ passport.use(new OpenIDStrategy({
 
 
 
-var app = express.createServer();
+var express = require("express");
+var app = express();
 
 // configure Express
 app.configure(function() {


### PR DESCRIPTION
Warning: express.createServer() is deprecated, express
applications no longer inherit from http.Server,
please use:

  var express = require("express");
  var app = express();