### PR TITLE
Update sign on example for Express 4.0

### DIFF
--- a/examples/signon/app.js
+++ b/examples/signon/app.js
@@ -1,4 +1,9 @@
 var express = require('express')
+  , morgan = require('morgan')
+  , cookieParser = require('cookie-parser')
+  , bodyParser = require('body-parser')
+  , methodOverride = require('method-override')
+  , expressSession = require('express-session')
   , passport = require('passport')
   , util = require('util')
   , OpenIDStrategy = require('passport-openid').Strategy;
@@ -44,24 +49,21 @@ passport.use(new OpenIDStrategy({
 
 
 
-var app = express.createServer();
+var app = express();
 
 // configure Express
-app.configure(function() {
-  app.set('views', __dirname + '/views');
-  app.set('view engine', 'ejs');
-  app.use(express.logger());
-  app.use(express.cookieParser());
-  app.use(express.bodyParser());
-  app.use(express.methodOverride());
-  app.use(express.session({ secret: 'keyboard cat' }));
-  // Initialize Passport!  Also use passport.session() middleware, to support
-  // persistent login sessions (recommended).
-  app.use(passport.initialize());
-  app.use(passport.session());
-  app.use(app.router);
-  app.use(express.static(__dirname + '/../../public'));
-});
+app.set('views', __dirname + '/views');
+app.set('view engine', 'ejs');
+app.use(morgan());
+app.use(cookieParser());
+app.use(bodyParser());
+app.use(methodOverride());
+app.use(expressSession({ secret: 'keyboard cat' }));
+// Initialize Passport!  Also use passport.session() middleware, to support
+// persistent login sessions (recommended).
+app.use(passport.initialize());
+app.use(passport.session());
+app.use(express.static(__dirname + '/../../public'));
 
 
 app.get('/', function(req, res){

--- a/examples/signon/package.json
+++ b/examples/signon/package.json
@@ -5,6 +5,11 @@
     "express": ">= 0.0.0",
     "ejs": ">= 0.0.0",
     "passport": ">= 0.0.0",
-    "passport-openid": ">= 0.0.0"
+    "passport-openid": ">= 0.0.0",
+    "morgan": ">=0.0.0",
+    "cookie-parser": ">=0.0.0",
+    "body-parser": ">=0.0.0",
+    "method-override": ">=0.0.0",
+    "express-session": ">=0.0.0"
   }
 }


### PR DESCRIPTION
Currently the signon example is broken out of the box due to breaking changes made in Express 4.0 (notably the removal of ```express.createServer()```)