### PR TITLE
deps: use openid 2.x branch

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   "main": "./lib/passport-openid",
   "dependencies": {
     "passport-strategy": "1.x.x",
-    "openid": "1.x.x"
+    "openid": "2.x.x"
   },
   "devDependencies": {
     "vows": "^0.8.1"


### PR DESCRIPTION
openid 1.x.x fails on Node v6.1.0, openid 2.x.x has needed fixes and should be used instead of 1.x.x.
fixes issue #35
